### PR TITLE
Fix Issue #23: Logging of pre-train performance causing errors in plot_learning 

### DIFF
--- a/src/model_free/off_policy.jl
+++ b/src/model_free/off_policy.jl
@@ -126,8 +126,10 @@ function POMDPs.solve(𝒮::OffPolicySolver, mdp)
 		steps!(s, 𝒮.buffer, Nsteps=Nfill, explore=true, i=𝒮.i, store=𝒮.interaction_storage, cb=(D)->𝒮.post_sample_callback(D, 𝒮=𝒮, info=info))
 	end 
 	
-	# Log the pre-train performance
-	log(𝒮.log, 𝒮.i, info, 𝒮=𝒮)
+	# Log the pre-train performance only when starting from scratch
+	if istart == 0
+	    log(𝒮.log, 𝒮.i, info, 𝒮=𝒮)
+	end
     
     # Loop over the desired number of environment interactions
     for 𝒮.i in range(𝒮.i, stop=istart + 𝒮.N - 𝒮.ΔN, step=𝒮.ΔN)

--- a/src/model_free/on_policy.jl
+++ b/src/model_free/on_policy.jl
@@ -87,7 +87,7 @@ function POMDPs.solve(𝒮::OnPolicySolver, mdp)
     # Log the pre-train performance only when starting from scratch
     if 𝒮.i == 0
         log(𝒮.log, 𝒮.i, 𝒮=𝒮)
-    end
+    end 
 
     # Loop over the desired number of environment interactions
     for 𝒮.i = range(𝒮.i, stop=𝒮.i + 𝒮.N - 𝒮.ΔN, step=𝒮.ΔN)

--- a/src/model_free/on_policy.jl
+++ b/src/model_free/on_policy.jl
@@ -84,8 +84,10 @@ function POMDPs.solve(𝒮::OnPolicySolver, mdp)
     s = Sampler(mdp, 𝒮.agent, S=𝒮.S, required_columns=𝒮.required_columns, λ=λ, max_steps=𝒮.max_steps, Vc=𝒮.Vc)
     isnothing(𝒮.log.sampler) && (𝒮.log.sampler = s)
 
-    # Log the pre-train performance
-    log(𝒮.log, 𝒮.i, 𝒮=𝒮)
+    # Log the pre-train performance only when starting from scratch
+    if 𝒮.i == 0
+        log(𝒮.log, 𝒮.i, 𝒮=𝒮)
+    end
 
     # Loop over the desired number of environment interactions
     for 𝒮.i = range(𝒮.i, stop=𝒮.i + 𝒮.N - 𝒮.ΔN, step=𝒮.ΔN)


### PR DESCRIPTION

Logs pre-train performance when starting a new training run. Prevents duplicate pre-train log entries when resuming training, which can lead to non-monotonic step values and errors in `plot_learning`.